### PR TITLE
Attempt to change parking lot render

### DIFF
--- a/inc/layer-amenity-points.xml.inc
+++ b/inc/layer-amenity-points.xml.inc
@@ -163,12 +163,12 @@
     <Rule>
       &maxscale_zoom15;
       <Filter>[amenity] = 'parking' and ([access] = 'public' or [access] = 'yes' or not [access] != '')</Filter>
-      <PointSymbolizer file="&symbols;/parking.p.16.png" allow-overlap="false" placement="interior"/>
+      <PolygonPatternSymbolizer file="&symbols;/parking.p.16.png" />
     </Rule>
     <Rule>
       &maxscale_zoom15;
       <Filter>[amenity] = 'parking' and ([access] != '' and not [access] = 'public' and not [access] = 'yes')</Filter>
-      <PointSymbolizer file="&symbols;/parking_private.p.16.png" allow-overlap="false" placement="interior"/>
+      <PolygonPatternSymbolizer file="&symbols;/parking_private.p.16.png" />
     </Rule>
     <Rule>
       &maxscale_zoom17;


### PR DESCRIPTION
https://trac.openstreetmap.org/ticket/2968

Swap from rendering a P as an icon / single point, to being a background area coloration (Assuming the majority of parking is a polygon).

Not tested properly, and probably breaks parking areas that are individual points, but it's a first attempt
